### PR TITLE
Light network servers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,7 +370,8 @@ if (ENABLE_EXTRA_WARNINGS)
     -Wold-style-definition
     -Wundef
     -Wignored-qualifiers
-    -Wfloat-conversion)
+    -Wfloat-conversion
+    -Wbad-function-cast)
 
 if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
   set(EXTRA_WARNINGS

--- a/Makefile.am
+++ b/Makefile.am
@@ -88,7 +88,8 @@ AM_CFLAGS += \
 	-Wundef \
 	-Wignored-qualifiers \
 	-Woverride-init \
-	-Wfloat-conversion
+	-Wfloat-conversion \
+	-Wbad-function-cast
 endif
 
 if ENABLE_DEBUG

--- a/lib/logmsg/tags.c
+++ b/lib/logmsg/tags.c
@@ -64,12 +64,15 @@ log_tags_get_by_name(const gchar *name)
      In both cases the return value is 0.
    */
   guint id;
+  gpointer key;
 
   g_assert(log_tags_hash != NULL);
 
   g_mutex_lock(&log_tags_lock);
 
-  id = GPOINTER_TO_UINT(g_hash_table_lookup(log_tags_hash, name)) - 1;
+  key = g_hash_table_lookup(log_tags_hash, name);
+  id = GPOINTER_TO_UINT(key) - 1;
+
   if (id == 0xffffffff)
     {
       if (log_tags_num < LOG_TAGS_MAX - 1)

--- a/lib/logmsg/tags.c
+++ b/lib/logmsg/tags.c
@@ -63,15 +63,13 @@ log_tags_get_by_name(const gchar *name)
 
      In both cases the return value is 0.
    */
-  guint id;
-  gpointer key;
 
   g_assert(log_tags_hash != NULL);
 
   g_mutex_lock(&log_tags_lock);
 
-  key = g_hash_table_lookup(log_tags_hash, name);
-  id = GPOINTER_TO_UINT(key) - 1;
+  gpointer key = g_hash_table_lookup(log_tags_hash, name);
+  guint id = GPOINTER_TO_UINT(key) - 1;
 
   if (id == 0xffffffff)
     {

--- a/lib/logthrdest/logthrdestdrv.c
+++ b/lib/logthrdest/logthrdestdrv.c
@@ -1097,6 +1097,7 @@ _create_workers(LogThreadedDestDriver *self)
 gboolean
 log_threaded_dest_driver_init_method(LogPipe *s)
 {
+  gpointer value;
   LogThreadedDestDriver *self = (LogThreadedDestDriver *)s;
   GlobalConfig *cfg = log_pipe_get_config(s);
 
@@ -1108,8 +1109,9 @@ log_threaded_dest_driver_init_method(LogPipe *s)
   if (self->time_reopen == -1)
     self->time_reopen = cfg->time_reopen;
 
-  self->shared_seq_num = GPOINTER_TO_INT(cfg_persist_config_fetch(cfg,
-                                         _format_seqnum_persist_name(self)));
+  value = cfg_persist_config_fetch(cfg, _format_seqnum_persist_name(self));
+  self->shared_seq_num = GPOINTER_TO_INT(value);
+
   if (!self->shared_seq_num)
     init_sequence_number(&self->shared_seq_num);
 

--- a/lib/logthrdest/logthrdestdrv.c
+++ b/lib/logthrdest/logthrdestdrv.c
@@ -1097,7 +1097,6 @@ _create_workers(LogThreadedDestDriver *self)
 gboolean
 log_threaded_dest_driver_init_method(LogPipe *s)
 {
-  gpointer value;
   LogThreadedDestDriver *self = (LogThreadedDestDriver *)s;
   GlobalConfig *cfg = log_pipe_get_config(s);
 
@@ -1109,8 +1108,8 @@ log_threaded_dest_driver_init_method(LogPipe *s)
   if (self->time_reopen == -1)
     self->time_reopen = cfg->time_reopen;
 
-  value = cfg_persist_config_fetch(cfg, _format_seqnum_persist_name(self));
-  self->shared_seq_num = GPOINTER_TO_INT(value);
+  gpointer persisted_value = cfg_persist_config_fetch(cfg, _format_seqnum_persist_name(self));
+  self->shared_seq_num = GPOINTER_TO_INT(persisted_value);
 
   if (!self->shared_seq_num)
     init_sequence_number(&self->shared_seq_num);

--- a/lib/rewrite/rewrite-set-tag.c
+++ b/lib/rewrite/rewrite-set-tag.c
@@ -100,6 +100,8 @@ log_rewrite_set_tag_new(LogTemplate *tag_template, gboolean value, GlobalConfig 
   self->super.process = _process;
   self->value = value;
 
+  self->tag_template = log_template_ref(tag_template);
+
   if (log_template_is_literal_string(tag_template))
     {
       const gchar *tag_name = log_template_get_literal_value(tag_template, NULL);
@@ -107,7 +109,6 @@ log_rewrite_set_tag_new(LogTemplate *tag_template, gboolean value, GlobalConfig 
     }
   else
     {
-      self->tag_template = log_template_ref(tag_template);
       self->tag_id = LOG_TAGS_UNDEF;
     }
 

--- a/lib/rewrite/tests/test_set_tag.c
+++ b/lib/rewrite/tests/test_set_tag.c
@@ -87,6 +87,42 @@ Test(set_tag, templates_in_set_tag)
   assert_log_message_doesnt_have_tag(msg, "tag-BARFOO");
 }
 
+Test(set_tag, clone_template)
+{
+  LogTemplate *template = log_template_new(cfg, "dummy");
+  cr_assert(log_template_compile(template, "not literal $MESSAGE", NULL));
+  LogRewrite *rewrite = log_rewrite_set_tag_new(template, true, cfg);
+
+  LogRewrite *clone = (LogRewrite *)log_pipe_clone(&rewrite->super);
+
+  cr_assert(log_pipe_init(&rewrite->super));
+  cr_assert(log_pipe_init(&clone->super));
+
+  cr_assert(log_pipe_deinit(&rewrite->super));
+  cr_assert(log_pipe_deinit(&clone->super));
+
+  log_pipe_unref(&rewrite->super);
+  log_pipe_unref(&clone->super);
+}
+
+Test(set_tag, clone_tag_id)
+{
+  LogTemplate *template = log_template_new(cfg, "dummy");
+  cr_assert(log_template_compile(template, "syslog", NULL));
+  LogRewrite *rewrite = log_rewrite_set_tag_new(template, true, cfg);
+
+  LogRewrite *clone = (LogRewrite *)log_pipe_clone(&rewrite->super);
+
+  cr_assert(log_pipe_init(&rewrite->super));
+  cr_assert(log_pipe_init(&clone->super));
+
+  cr_assert(log_pipe_deinit(&rewrite->super));
+  cr_assert(log_pipe_deinit(&clone->super));
+
+  log_pipe_unref(&rewrite->super);
+  log_pipe_unref(&clone->super);
+}
+
 static void
 setup(void)
 {

--- a/lib/stats/aggregator/stats-change-per-second.c
+++ b/lib/stats/aggregator/stats-change-per-second.c
@@ -246,12 +246,13 @@ static void
 _calc_sum(StatsAggregatorCPS *self, CPSLogic *logic, time_t *now)
 {
   gsize diff = _get_count(self) - _get_last_count(logic);
+  gdouble elapsed_time_since_last;
   _set_last_count(logic, _get_count(self));
 
   if (!_is_less_then_duration(self, logic, now))
     {
-      gsize elapsed_time_since_last = (gsize)_calc_sec_between_time(&self->last_add_time, now);
-      diff -= _get_average(logic) * elapsed_time_since_last;
+      elapsed_time_since_last = _calc_sec_between_time(&self->last_add_time, now);
+      diff -= _get_average(logic) * (gsize)elapsed_time_since_last;
     }
 
   _add_to_sum(logic, diff);
@@ -261,8 +262,11 @@ _calc_sum(StatsAggregatorCPS *self, CPSLogic *logic, time_t *now)
 static void
 _calc_average(StatsAggregatorCPS *self, CPSLogic *logic, time_t *now)
 {
-  gsize elapsed_time = (gsize)_calc_sec_between_time(&self->init_time, now);
-  gsize divisor = (_is_less_then_duration(self, logic, now)) ? elapsed_time : logic->duration;
+  gdouble elapsed_time;
+  gsize divisor;
+
+  elapsed_time = _calc_sec_between_time(&self->init_time, now);
+  divisor = (_is_less_then_duration(self, logic, now)) ? (gsize)elapsed_time : logic->duration;
   if (divisor <= 0) divisor = 1;
   gsize sum = _get_sum(logic);
 
@@ -274,7 +278,7 @@ _calc_average(StatsAggregatorCPS *self, CPSLogic *logic, time_t *now)
             evt_tag_long("sum", sum),
             evt_tag_long("divisor", divisor),
             evt_tag_long("cps", (sum/divisor)),
-            evt_tag_long("delta_time_since_start", elapsed_time));
+            evt_tag_long("delta_time_since_start", (gsize)elapsed_time));
 }
 
 static void

--- a/lib/stats/aggregator/stats-change-per-second.c
+++ b/lib/stats/aggregator/stats-change-per-second.c
@@ -240,7 +240,7 @@ _is_less_then_duration(StatsAggregatorCPS *self, CPSLogic *logic, time_t *now)
   if (logic->duration == -1)
     return TRUE;
 
-  return (gsize)_calc_sec_between_time(&self->init_time, now) <= logic->duration;
+  return _calc_sec_between_time(&self->init_time, now) <= logic->duration;
 }
 
 static void
@@ -251,8 +251,7 @@ _calc_sum(StatsAggregatorCPS *self, CPSLogic *logic, time_t *now)
 
   if (!_is_less_then_duration(self, logic, now))
     {
-      gsize elapsed_time_since_last = _calc_sec_between_time(&self->last_add_time, now);
-      diff -= _get_average(logic) * elapsed_time_since_last;
+      diff -= _get_average(logic) * _calc_sec_between_time(&self->last_add_time, now);
     }
 
   _add_to_sum(logic, diff);
@@ -262,7 +261,7 @@ _calc_sum(StatsAggregatorCPS *self, CPSLogic *logic, time_t *now)
 static void
 _calc_average(StatsAggregatorCPS *self, CPSLogic *logic, time_t *now)
 {
-  gsize elapsed_time;
+  time_t elapsed_time;
   gsize divisor;
 
   elapsed_time = _calc_sec_between_time(&self->init_time, now);
@@ -278,7 +277,7 @@ _calc_average(StatsAggregatorCPS *self, CPSLogic *logic, time_t *now)
             evt_tag_long("sum", sum),
             evt_tag_long("divisor", divisor),
             evt_tag_long("cps", (sum/divisor)),
-            evt_tag_long("delta_time_since_start", (gsize)elapsed_time));
+            evt_tag_long("delta_time_since_start", elapsed_time));
 }
 
 static void

--- a/lib/template/macros.c
+++ b/lib/template/macros.c
@@ -725,10 +725,13 @@ log_macro_lookup(const gchar *macro, gint len)
 {
   gchar buf[256];
   gint macro_id;
+  gpointer p;
 
   g_assert(macro_hash);
   g_strlcpy(buf, macro, MIN(sizeof(buf), len+1));
-  macro_id = GPOINTER_TO_INT(g_hash_table_lookup(macro_hash, buf));
+  p = g_hash_table_lookup(macro_hash, buf);
+  macro_id = GPOINTER_TO_INT(p);
+
   return macro_id;
 }
 

--- a/lib/template/macros.c
+++ b/lib/template/macros.c
@@ -725,12 +725,11 @@ log_macro_lookup(const gchar *macro, gint len)
 {
   gchar buf[256];
   gint macro_id;
-  gpointer p;
 
   g_assert(macro_hash);
   g_strlcpy(buf, macro, MIN(sizeof(buf), len+1));
-  p = g_hash_table_lookup(macro_hash, buf);
-  macro_id = GPOINTER_TO_INT(p);
+  gpointer hash_key = g_hash_table_lookup(macro_hash, buf);
+  macro_id = GPOINTER_TO_INT(hash_key);
 
   return macro_id;
 }

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -843,13 +843,12 @@ _sd_open_stream(AFSocketSourceDriver *self)
 {
   GlobalConfig *cfg = log_pipe_get_config(&self->super.super.super);
   gint sock = -1;
-  gpointer fd;
   if (self->connections_kept_alive_across_reloads)
     {
       /* NOTE: this assumes that fd 0 will never be used for listening fds,
        * main.c opens fd 0 so this assumption can hold */
-      fd = cfg_persist_config_fetch(cfg, afsocket_sd_format_listener_name(self));
-      sock = GPOINTER_TO_UINT(fd) - 1;
+      gpointer config_result = cfg_persist_config_fetch(cfg, afsocket_sd_format_listener_name(self));
+      sock = GPOINTER_TO_UINT(config_result) - 1;
 
     }
 

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -843,13 +843,14 @@ _sd_open_stream(AFSocketSourceDriver *self)
 {
   GlobalConfig *cfg = log_pipe_get_config(&self->super.super.super);
   gint sock = -1;
+  gpointer fd;
   if (self->connections_kept_alive_across_reloads)
     {
       /* NOTE: this assumes that fd 0 will never be used for listening fds,
        * main.c opens fd 0 so this assumption can hold */
-      sock = GPOINTER_TO_UINT(
-               cfg_persist_config_fetch(cfg, afsocket_sd_format_listener_name(self))) -
-             1;
+      fd = cfg_persist_config_fetch(cfg, afsocket_sd_format_listener_name(self));
+      sock = GPOINTER_TO_UINT(fd) - 1;
+
     }
 
   if (sock == -1)

--- a/modules/basicfuncs/numeric-funcs.c
+++ b/modules/basicfuncs/numeric-funcs.c
@@ -360,7 +360,10 @@ tf_num_ceil(LogMessage *msg, gint argc, GString *argv[], GString *result, LogMes
     }
 
   *type = LM_VT_INT64;
-  format_int64_padded(result, 0, ' ', 10, (gint64)ceil(number_as_double(n)));
+  gdouble number;
+
+  number = ceil(number_as_double(n));
+  format_int64_padded(result, 0, ' ', 10, (gint64)number);
 }
 
 TEMPLATE_FUNCTION_SIMPLE(tf_num_ceil);
@@ -388,7 +391,10 @@ tf_num_floor(LogMessage *msg, gint argc, GString *argv[], GString *result, LogMe
     }
 
   *type = LM_VT_INT64;
-  format_int64_padded(result, 0, ' ', 10, (gint64)floor(number_as_double(n)));
+  gdouble number;
+
+  number = floor(number_as_double(n));
+  format_int64_padded(result, 0, ' ', 10, (gint64)number);
 }
 
 TEMPLATE_FUNCTION_SIMPLE(tf_num_floor);

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -38,8 +38,7 @@
 #define POINTER_TO_LOG_PATH_OPTIONS(ptr, lpo) \
 ({ \
   gpointer p = ptr; \
-  LogPathOptions *opts = lpo; \
-  (lpo)->ack_needed = (GPOINTER_TO_INT(p) & ~0x80000000); opts; \
+  (lpo)->ack_needed = (GPOINTER_TO_INT(p) & ~0x80000000); \
 })
 
 typedef gboolean (*QDiskSerializeFunc)(SerializeArchive *sa, gpointer user_data);

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -35,7 +35,12 @@
  * uses this breaks, as it passes the result of a g_queue_pop_head call,
  * which has side effects.
  */
-#define POINTER_TO_LOG_PATH_OPTIONS(ptr, lpo) (lpo)->ack_needed = (GPOINTER_TO_INT(ptr) & ~0x80000000)
+#define POINTER_TO_LOG_PATH_OPTIONS(ptr, lpo) \
+({ \
+  gpointer p = ptr; \
+  LogPathOptions *opts = lpo; \
+  (lpo)->ack_needed = (GPOINTER_TO_INT(p) & ~0x80000000); opts; \
+})
 
 typedef gboolean (*QDiskSerializeFunc)(SerializeArchive *sa, gpointer user_data);
 typedef gboolean (*QDiskDeSerializeFunc)(SerializeArchive *sa, gpointer user_data);

--- a/modules/diskq/tests/test_diskq_truncate.c
+++ b/modules/diskq/tests/test_diskq_truncate.c
@@ -96,8 +96,12 @@ _calculate_full_disk_message_num(LogQueueDisk *queue_disk)
    * Assumes that only empty messages are stored.
    */
   QDisk *qdisk = queue_disk->qdisk;
+  gdouble num_messages;
+
   gsize msg_size = _calculate_serialized_empty_message_size(queue_disk);
-  return (gint64) ceil((qdisk->options->disk_buf_size - QDISK_RESERVED_SPACE) / (double) msg_size);
+  num_messages = ceil((qdisk->options->disk_buf_size - QDISK_RESERVED_SPACE) / (double) msg_size);
+
+  return (gint64)num_messages;
 }
 
 static gint64

--- a/modules/diskq/tests/test_diskq_truncate.c
+++ b/modules/diskq/tests/test_diskq_truncate.c
@@ -96,12 +96,11 @@ _calculate_full_disk_message_num(LogQueueDisk *queue_disk)
    * Assumes that only empty messages are stored.
    */
   QDisk *qdisk = queue_disk->qdisk;
-  gdouble num_messages;
 
   gsize msg_size = _calculate_serialized_empty_message_size(queue_disk);
-  num_messages = ceil((qdisk->options->disk_buf_size - QDISK_RESERVED_SPACE) / (double) msg_size);
+  gint num_messages = llrint(ceil((qdisk->options->disk_buf_size - QDISK_RESERVED_SPACE) / (double) msg_size));
 
-  return (gint64)num_messages;
+  return num_messages;
 }
 
 static gint64

--- a/news/bugfix-4065.md
+++ b/news/bugfix-4065.md
@@ -1,0 +1,1 @@
+set-tag: fix cloning issue when string literal were used (see #4062)

--- a/tests/light/functional_tests/Makefile.am
+++ b/tests/light/functional_tests/Makefile.am
@@ -5,6 +5,7 @@ EXTRA_DIST += \
 	tests/light/functional_tests/config_change/test_manipulating_config_between_reload.py \
 	tests/light/functional_tests/conftest.py \
 	tests/light/functional_tests/destination_drivers/example_destination/test_example_destination.py \
+	tests/light/functional_tests/destination_drivers/network_destination/test_network_destination_transport.py \
 	tests/light/functional_tests/destination_drivers/snmp_destination/general/test_snmp_destination_acceptance.py \
 	tests/light/functional_tests/destination_drivers/snmp_destination/general/test_snmp_destination_missing_snmp_obj.py \
 	tests/light/functional_tests/destination_drivers/snmp_destination/general/test_snmp_destination_missing_trap_obj.py \

--- a/tests/light/functional_tests/destination_drivers/network_destination/test_network_destination_transport.py
+++ b/tests/light/functional_tests/destination_drivers/network_destination/test_network_destination_transport.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2021 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import pytest
+
+
+@pytest.mark.netcat
+@pytest.mark.parametrize(
+    "transport", [
+        None,
+        "tcp",
+        "udp",
+    ], ids=["default", "tcp", "udp"],
+)
+def test_network_destination_transport(config, syslog_ng, port_allocator, transport):
+    counter = 100
+    message = "message text"
+
+    generator_source = config.create_example_msg_generator_source(num=counter, freq=0.0001, template=config.stringify(message))
+    if transport is not None:
+        network_destination = config.create_network_destination(ip="localhost", port=port_allocator(), transport=transport)
+    else:
+        network_destination = config.create_network_destination(ip="localhost", port=port_allocator())
+    config.create_logpath(statements=[generator_source, network_destination])
+
+    network_destination.start_listener()
+    syslog_ng.start(config)
+    assert network_destination.read_until_logs([message] * counter)

--- a/tests/light/src/Makefile.am
+++ b/tests/light/src/Makefile.am
@@ -20,6 +20,7 @@ EXTRA_DIST += \
 	tests/light/src/driver_io/__init__.py \
 	tests/light/src/driver_io/network/__init__.py \
 	tests/light/src/driver_io/network/network_io.py \
+	tests/light/src/driver_io/message_readers.py \
 	tests/light/src/executors/command_executor.py \
 	tests/light/src/executors/__init__.py \
 	tests/light/src/executors/process_executor.py \

--- a/tests/light/src/Makefile.am
+++ b/tests/light/src/Makefile.am
@@ -5,6 +5,7 @@ EXTRA_DIST += \
 	tests/light/src/common/blocking.py \
 	tests/light/src/common/__init__.py \
 	tests/light/src/common/file.py \
+	tests/light/src/common/network.py \
 	tests/light/src/common/network_operations.py \
 	tests/light/src/common/operations.py \
 	tests/light/src/common/pytest_operations.py \

--- a/tests/light/src/Makefile.am
+++ b/tests/light/src/Makefile.am
@@ -1,6 +1,7 @@
 
 #find -name '*.py'|awk '{ print "\ttests/light/src/"substr($0,3); }'|sort
 EXTRA_DIST += \
+	tests/light/src/common/asynchronous.py \
 	tests/light/src/common/blocking.py \
 	tests/light/src/common/__init__.py \
 	tests/light/src/common/file.py \

--- a/tests/light/src/Makefile.am
+++ b/tests/light/src/Makefile.am
@@ -46,6 +46,7 @@ EXTRA_DIST += \
 	tests/light/src/syslog_ng_config/statements/destinations/example_destination.py \
 	tests/light/src/syslog_ng_config/statements/destinations/file_destination.py \
 	tests/light/src/syslog_ng_config/statements/destinations/__init__.py \
+	tests/light/src/syslog_ng_config/statements/destinations/network_destination.py \
 	tests/light/src/syslog_ng_config/statements/destinations/snmp_destination.py \
 	tests/light/src/syslog_ng_config/statements/filters/filter.py \
 	tests/light/src/syslog_ng_config/statements/filters/__init__.py \

--- a/tests/light/src/common/asynchronous.py
+++ b/tests/light/src/common/asynchronous.py
@@ -1,0 +1,58 @@
+#############################################################################
+# Copyright (c) 2021 One Identity
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+import asyncio
+import concurrent
+import threading
+
+class BackgroundEventLoop(object):
+    """Singleton event loop running in the background"""
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(BackgroundEventLoop, cls).__new__(cls)
+            cls._instance._init()
+        return cls._instance
+
+    def _init(self):
+        self.loop = asyncio.new_event_loop()
+        self.thread = threading.Thread(target=self._run_event_loop_func, daemon=True)
+        self.thread.start()
+
+    def _run_event_loop_func(self):
+        asyncio.set_event_loop(self.loop)
+        self.loop.run_forever()
+
+    def run_async(self, async_func):
+        return asyncio.run_coroutine_threadsafe(async_func, self.loop)
+
+    def wait_async_result(self, async_func, timeout):
+        future = self.run_async(async_func)
+        try:
+            return future.result(timeout=timeout)
+        except (asyncio.TimeoutError, TimeoutError, concurrent.futures.TimeoutError) as err:
+            future.cancel()
+            raise asyncio.TimeoutError("Network operation timed out") from err
+
+    def stop(self):
+        self.loop.call_soon_threadsafe(self.loop.stop)

--- a/tests/light/src/common/network.py
+++ b/tests/light/src/common/network.py
@@ -1,0 +1,127 @@
+#############################################################################
+# Copyright (c) 2022 One Identity
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import asyncio
+import socket
+from abc import ABC
+from abc import abstractmethod
+
+from src.common.asynchronous import BackgroundEventLoop
+
+class SingleConnectionStreamServer(ABC):
+    def __init__(self):
+        self._event_loop = BackgroundEventLoop()
+        self._server = None
+        self._client = self._event_loop.run_async(self._create_client()).result()
+
+    async def start(self):
+        server_res = await self._start_server()
+        self._server = server_res
+
+    async def stop(self):
+        await self._stop_server()
+        await self.close_client()
+
+    async def close_client(self):
+        """After a client connection is accepted, new connections will be rejected until this method is called"""
+        await self._client.close()
+
+    async def _create_client(self):
+        return self.Client()
+
+    @abstractmethod
+    async def _start_server(self):
+        pass
+
+    async def _stop_server(self):
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+
+    async def _client_accepted_cb(self, reader, writer):
+        self._client.accept_connection(reader, writer)
+
+    async def readexactly(self, n):
+        await self._client.wait_for_client_connection()
+        return await self._client._reader.readexactly(n)
+
+    async def readuntil(self, separator=b'\n'):
+        await self._client.wait_for_client_connection()
+        return await self._client._reader.readuntil(separator)
+
+    async def readline(self):
+        await self._client.wait_for_client_connection()
+        return await self._client._reader.readline()
+
+    async def write(self, data):
+        await self._client.wait_for_client_connection()
+        self._client._writer.write(data)
+        await self._client._writer.drain()
+
+    class Client(object):
+        def __init__(self):
+            self._connection_accepted = asyncio.Event()
+            self._reader = None
+            self._writer = None
+
+        def accept_connection(self, reader, writer):
+            if self._connection_accepted.is_set():
+                writer.close()
+                return
+            self._reader = reader
+            self._writer = writer
+            self._connection_accepted.set()
+
+        async def wait_for_client_connection(self):
+            await self._connection_accepted.wait()
+
+        async def close(self):
+            if not self._connection_accepted.is_set():
+                return
+            self._writer.close()
+            await self._writer.wait_closed()
+            self._connection_accepted.clear()
+
+
+class SingleConnectionTCPServer(SingleConnectionStreamServer):
+    def __init__(self, port, host=None, ip_protocol_version=socket.AF_INET, ssl=None):
+        super(SingleConnectionTCPServer, self).__init__()
+        self._host = host
+        self._port = port
+        self._family = ip_protocol_version
+        self._ssl = ssl
+
+    async def _start_server(self):
+        server = await asyncio.start_server(self._client_accepted_cb, self._host, self._port, family=self._family, ssl=self._ssl)
+        await server.start_serving()
+        return server
+
+
+class SingleConnectionUnixStreamServer(SingleConnectionStreamServer):
+    def __init__(self, path, ssl=None):
+        super(SingleConnectionUnixStreamServer, self).__init__()
+        self._path = path
+        self._ssl = ssl
+
+    async def _start_server(self):
+        server = await asyncio.start_unix_server(self._client_accepted_cb, self._path, ssl=self._ssl)
+        await server.start_serving()
+        return server

--- a/tests/light/src/common/network.py
+++ b/tests/light/src/common/network.py
@@ -125,3 +125,49 @@ class SingleConnectionUnixStreamServer(SingleConnectionStreamServer):
         server = await asyncio.start_unix_server(self._client_accepted_cb, self._path, ssl=self._ssl)
         await server.start_serving()
         return server
+
+
+class DatagramServer(ABC):
+    def __init__(self):
+        self._event_loop = BackgroundEventLoop()
+        self._sock = None
+
+    @abstractmethod
+    async def start(self):
+        pass
+
+    async def stop(self):
+        if self._sock is not None:
+            self._sock.close()
+            self._sock = None
+
+    async def read_dgram(self, maxsize=65536):
+        return await self._event_loop.loop.sock_recv(self._sock, maxsize)
+
+    async def write_dgram(self, data):
+        raise NotImplementedError
+
+
+class UDPServer(DatagramServer):
+    def __init__(self, port, host=None, ip_protocol_version=socket.AF_INET):
+        super(UDPServer, self).__init__()
+        self._host = '' if host is None else host
+        self._port = port
+        self._family = ip_protocol_version
+
+    async def start(self):
+        self._sock = socket.socket(self._family, socket.SOCK_DGRAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.setblocking(False)
+        self._sock.bind((self._host, self._port))
+
+
+class UnixDatagramServer(DatagramServer):
+    def __init__(self, path):
+        super(UnixDatagramServer, self).__init__()
+        self._path = path
+
+    async def start(self):
+        self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+        self._sock.setblocking(False)
+        self._sock.bind(self._path)

--- a/tests/light/src/driver_io/file/file_io.py
+++ b/tests/light/src/driver_io/file/file_io.py
@@ -28,7 +28,7 @@ class FileIO():
         self.__readable_file = File(file_path)
         self.__writeable_file = File(file_path)
 
-    def read_number_of_lines(self, counter):
+    def read_number_of_messages(self, counter):
         if not self.__readable_file.is_opened():
             if not self.__readable_file.wait_for_creation():
                 raise Exception("{} was not created in time.".format(self.__readable_file.path))
@@ -36,7 +36,7 @@ class FileIO():
 
         return self.__readable_file.wait_for_number_of_lines(counter)
 
-    def read_until_lines(self, lines):
+    def read_until_messages(self, lines):
         if not self.__readable_file.is_opened():
             if not self.__readable_file.wait_for_creation():
                 raise Exception("{} was not created in time.".format(self.__readable_file.path))

--- a/tests/light/src/driver_io/file/tests/test_file_io.py
+++ b/tests/light/src/driver_io/file/tests/test_file_io.py
@@ -26,7 +26,7 @@ from src.driver_io.file.file_io import FileIO
 def test_file_io_write_read(temp_file, test_message):
     fileio = FileIO(temp_file)
     fileio.write(test_message)
-    output = fileio.read_number_of_lines(1)
+    output = fileio.read_number_of_messages(1)
     assert [test_message] == output
 
 
@@ -34,5 +34,5 @@ def test_file_io_multiple_write_read(temp_file, test_message):
     fileio = FileIO(temp_file)
     fileio.write(test_message)
     fileio.write(test_message)
-    output = fileio.read_number_of_lines(2)
+    output = fileio.read_number_of_messages(2)
     assert [test_message, test_message] == output

--- a/tests/light/src/driver_io/message_readers.py
+++ b/tests/light/src/driver_io/message_readers.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2022 One Identity
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from src.common.asynchronous import BackgroundEventLoop
+
+class SingleLineStreamReader(object):
+    def __init__(self, stream):
+        self._stream = stream
+
+    def wait_for_messages(self, lines, timeout):
+        return BackgroundEventLoop().wait_async_result(self._read_until_lines_found(lines), timeout=timeout)
+
+    def wait_for_number_of_messages(self, number_of_lines, timeout):
+        return BackgroundEventLoop().wait_async_result(self._read_number_of_lines(number_of_lines), timeout=timeout)
+
+    async def _read_until_lines_found(self, lines):
+        read_lines = []
+        lines_to_find = lines.copy()
+
+        while len(lines_to_find) > 0:
+            line = await self._stream.readline()
+            if len(line) == 0:
+                raise Exception("Could not find all lines. Remaining lines to find: {} Lines found: {}".format(lines_to_find, read_lines))
+            line = line.decode("utf-8")
+            read_lines.append(line)
+            _list_remove_partially_matching_element(lines_to_find, line)
+        return read_lines
+
+    async def _read_number_of_lines(self, number_of_lines):
+        lines = []
+        for i in range(number_of_lines):
+            line = await self._stream.readline()
+            if len(line) == 0:
+                raise Exception("Could not read {} number of lines. Connection closed after {} lines".format(number_of_lines, len(lines)))
+            lines.append(line.decode("utf-8"))
+        return lines
+
+
+class DatagramReader(object):
+    def __init__(self, datagram_server):
+        self._datagram_server = datagram_server
+
+    def wait_for_messages(self, lines, timeout, maxsize=65536):
+        return BackgroundEventLoop().wait_async_result(self._read_until_dgrams_found(lines, maxsize), timeout=timeout)
+
+    def wait_for_number_of_messages(self, number_of_msgs, timeout, maxsize=65536):
+        return BackgroundEventLoop().wait_async_result(self._read_number_of_dgrams(number_of_msgs, maxsize), timeout=timeout)
+
+    async def _read_until_dgrams_found(self, dgrams, maxsize):
+        read_dgrams = []
+        dgrams_to_find = dgrams.copy()
+
+        while len(dgrams_to_find) != 0:
+            dgram = await self._datagram_server.read_dgram(maxsize)
+            if len(dgram) == 0:
+                raise Exception("Could not find all datagrams. Remaining dgrams to find: {} Lines found: {}".format(dgrams_to_find, read_dgrams))
+            dgram = dgram.decode("utf-8")
+            read_dgrams.append(dgram)
+            _list_remove_partially_matching_element(dgrams_to_find, dgram)
+        return read_dgrams
+
+    async def _read_number_of_dgrams(self, number_of_dgrams, maxsize):
+        msgs = []
+        for i in range(number_of_dgrams):
+            msg = await self._datagram_server.read_dgram(maxsize)
+            if len(msg) == 0:
+                raise Exception("Could not read {} number of datagrams. Connection closed after {}".format(number_of_dgrams, len(msgs)))
+            msgs.append(msg.decode("utf-8"))
+
+        return msgs
+
+
+class FramedStreamReader(object):
+    """RFC6587 message reader for the syslog() driver"""
+    # TODO msg_length = readuntil(' '); msg = readexactly(msg_length)
+    pass
+
+
+# FileIO and this method too operate on partial string matches
+# TODO: LogMessage instances should be used instead, matching the full msg body
+def _list_remove_partially_matching_element(list, elem):
+    for l in list:
+        if l in elem:
+            list.remove(l)
+            return True
+    return False

--- a/tests/light/src/driver_io/network/network_io.py
+++ b/tests/light/src/driver_io/network/network_io.py
@@ -20,6 +20,7 @@
 # COPYING for details.
 #
 #############################################################################
+import atexit
 import socket
 from enum import Enum
 from enum import IntEnum
@@ -27,8 +28,13 @@ from enum import IntEnum
 from pathlib2 import Path
 
 import src.testcase_parameters.testcase_parameters as tc_parameters
+from src.common.blocking import DEFAULT_TIMEOUT
+from src.common.asynchronous import BackgroundEventLoop
 from src.common.file import File
+from src.common.network import SingleConnectionTCPServer
+from src.common.network import UDPServer
 from src.common.random_id import get_unique_id
+from src.driver_io import message_readers
 from src.helpers.loggen.loggen import Loggen
 
 
@@ -38,6 +44,10 @@ class NetworkIO():
         self.__port = port
         self.__transport = transport
         self.__ip_proto_version = NetworkIO.IPProtoVersion.V4 if ip_proto_version is None else ip_proto_version
+        self.__server = None
+        self.__message_reader = None
+
+        atexit.register(self.stop_listener)
 
     def write(self, content, rate=None):
         loggen_input_file_path = Path(tc_parameters.WORKING_DIR, "loggen_input_{}.txt".format(get_unique_id()))
@@ -48,6 +58,22 @@ class NetworkIO():
         loggen_input_file.close()
 
         Loggen().start(self.__ip, self.__port, read_file=str(loggen_input_file_path), dont_parse=True, permanent=True, rate=rate, **self.__transport.value)
+
+    def start_listener(self):
+        self.__message_reader, self.__server = self.__transport.construct(self.__port, self.__ip, self.__ip_proto_version)
+        BackgroundEventLoop().wait_async_result(self.__server.start(), timeout=DEFAULT_TIMEOUT)
+
+    def stop_listener(self):
+        if self.__message_reader is not None:
+            BackgroundEventLoop().wait_async_result(self.__server.stop(), timeout=DEFAULT_TIMEOUT)
+            self.__message_reader = None
+            self.__server = None
+
+    def read_number_of_messages(self, counter, timeout=DEFAULT_TIMEOUT):
+        return self.__message_reader.wait_for_number_of_messages(counter, timeout)
+
+    def read_until_messages(self, lines, timeout=DEFAULT_TIMEOUT):
+        return self.__message_reader.wait_for_messages(lines, timeout)
 
     class IPProtoVersion(IntEnum):
         V4 = socket.AF_INET
@@ -60,3 +86,16 @@ class NetworkIO():
         PROXIED_TCP = {"inet": True, "stream": True}
         PROXIED_TLS = {"use_ssl": True}
         PROXIED_TLS_PASSTHROUGH = {"use_ssl": True, "proxied_tls_passthrough": True}
+
+        def construct(self, port, host=None, ip_proto_version=None):
+            def _construct(server, reader_class):
+                return reader_class(server), server
+
+            transport_mapping = {
+                NetworkIO.Transport.TCP: lambda: _construct(SingleConnectionTCPServer(port, host, ip_proto_version), message_readers.SingleLineStreamReader),
+                NetworkIO.Transport.UDP: lambda: _construct(UDPServer(port, host, ip_proto_version), message_readers.DatagramReader),
+                # NetworkIO.Transport.TLS: SingleLineMessageReader(SingleConnectionTCPServer(port, host, ip_proto_version, ssl=TODO)),
+                # Framed: FramedStreamReader(SingleConnectionTCPServer())
+                # Frarmed TLS: FramedStreamReader(SingleConnectionTCPServer(ssl=TODO))
+            }
+            return transport_mapping[self]()

--- a/tests/light/src/driver_io/network/network_io.py
+++ b/tests/light/src/driver_io/network/network_io.py
@@ -20,7 +20,9 @@
 # COPYING for details.
 #
 #############################################################################
+import socket
 from enum import Enum
+from enum import IntEnum
 
 from pathlib2 import Path
 
@@ -31,10 +33,11 @@ from src.helpers.loggen.loggen import Loggen
 
 
 class NetworkIO():
-    def __init__(self, ip, port, transport):
+    def __init__(self, ip, port, transport, ip_proto_version=None):
         self.__ip = ip
         self.__port = port
         self.__transport = transport
+        self.__ip_proto_version = NetworkIO.IPProtoVersion.V4 if ip_proto_version is None else ip_proto_version
 
     def write(self, content, rate=None):
         loggen_input_file_path = Path(tc_parameters.WORKING_DIR, "loggen_input_{}.txt".format(get_unique_id()))
@@ -45,6 +48,10 @@ class NetworkIO():
         loggen_input_file.close()
 
         Loggen().start(self.__ip, self.__port, read_file=str(loggen_input_file_path), dont_parse=True, permanent=True, rate=rate, **self.__transport.value)
+
+    class IPProtoVersion(IntEnum):
+        V4 = socket.AF_INET
+        V6 = socket.AF_INET6
 
     class Transport(Enum):
         TCP = {"inet": True, "stream": True}

--- a/tests/light/src/syslog_ng_config/statements/destinations/example_destination.py
+++ b/tests/light/src/syslog_ng_config/statements/destinations/example_destination.py
@@ -41,7 +41,7 @@ class ExampleDestination(DestinationDriver):
         return self.read_logs(1)[0]
 
     def read_logs(self, counter):
-        return self.io.read_number_of_lines(counter)
+        return self.io.read_number_of_messages(counter)
 
     def read_until_logs(self, logs):
-        return self.io.read_until_lines(logs)
+        return self.io.read_until_messages(logs)

--- a/tests/light/src/syslog_ng_config/statements/destinations/file_destination.py
+++ b/tests/light/src/syslog_ng_config/statements/destinations/file_destination.py
@@ -41,7 +41,7 @@ class FileDestination(DestinationDriver):
         return self.read_logs(1)[0]
 
     def read_logs(self, counter):
-        return self.io.read_number_of_lines(counter)
+        return self.io.read_number_of_messages(counter)
 
     def read_until_logs(self, logs):
-        return self.io.read_until_lines(logs)
+        return self.io.read_until_messages(logs)

--- a/tests/light/src/syslog_ng_config/statements/destinations/network_destination.py
+++ b/tests/light/src/syslog_ng_config/statements/destinations/network_destination.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2021 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from src.driver_io.network.network_io import NetworkIO
+from src.syslog_ng_config.statements.destinations.destination_driver import DestinationDriver
+
+
+def map_transport(transport):
+    mapping = {
+        "tcp": NetworkIO.Transport.TCP,
+        "udp": NetworkIO.Transport.UDP,
+    }
+    transport = transport.replace("_", "-").replace("'", "").replace('"', "").lower()
+
+    return mapping[transport]
+
+
+def create_io(ip, options):
+    transport = options["transport"] if "transport" in options else "tcp"
+
+    return NetworkIO(ip, options["port"], map_transport(transport))
+
+
+class NetworkDestination(DestinationDriver):
+    def __init__(self, ip, **options):
+        self.driver_name = "network"
+        self.ip = ip
+        self.io = create_io(self.ip, options)
+        super(NetworkDestination, self).__init__([self.ip], options)
+
+    def start_listener(self):
+        self.io.start_listener()
+
+    def stop_listener(self):
+        self.io.stop_listener()
+
+    def read_log(self):
+        return self.read_logs(1)[0]
+
+    def read_logs(self, counter):
+        return self.io.read_number_of_messages(counter)
+
+    def read_until_logs(self, logs):
+        return self.io.read_until_messages(logs)

--- a/tests/light/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/light/src/syslog_ng_config/syslog_ng_config.py
@@ -28,6 +28,7 @@ from src.syslog_ng_config.renderer import ConfigRenderer
 from src.syslog_ng_config.statement_group import StatementGroup
 from src.syslog_ng_config.statements.destinations.example_destination import ExampleDestination
 from src.syslog_ng_config.statements.destinations.file_destination import FileDestination
+from src.syslog_ng_config.statements.destinations.network_destination import NetworkDestination
 from src.syslog_ng_config.statements.destinations.snmp_destination import SnmpDestination
 from src.syslog_ng_config.statements.filters.filter import Filter
 from src.syslog_ng_config.statements.filters.filter import RateLimit
@@ -140,6 +141,9 @@ class SyslogNgConfig(object):
 
     def create_snmp_destination(self, **options):
         return SnmpDestination(**options)
+
+    def create_network_destination(self, **options):
+        return NetworkDestination(**options)
 
     def create_db_parser(self, config, **options):
         return DBParser(config, **options)


### PR DESCRIPTION
This PR replaces the Netcat network IO with real Python servers.
This makes it possible/easier to track connections properly, detect I/O errors, react to timeouts, and implement non-trivial stream-based readers, such as multi-line/framed readers.

----

The PR adds the following classes that operate on a stream-based medium:
- `SingleConnectionTCPServer` is a basic TCP/TLS server implementation
- `UnixStreamServer` is the same, but it operates on Unix domain stream sockets.

The public interface is the following:
- `start()`, `stop()`, `close_client()`
- `readexactly(n)`, `readuntil(separator)`, `readline()`, `write(data)`

----

`UDPServer` and `UnixDatagramServer` are datagram-based servers.

Public interface:
- `start()`, `stop()`
- `read_dgram()`, `write_dgram(data)`

----

I also added the following readers for `NetworkIO`, so we can support framed (RFC6587) readers and other complex protocols as well (internal).

- `SingleLineStreamReader`: reads lines using a stream-based server
- `FramedStreamReader`: placeholder for a RFC6587 stream reader
- `DatagramReader`: reads datagrams from a dgram-based server


Note: Using async and asyncio was not an essential decision, blocking on each async call has no advantage over a blocking threaded implementation. async is used here because the streaming and thread synchronization APIs of asyncio are elegant and easier to understand in my opinion.